### PR TITLE
Fixed translation of Login in czech

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -281,7 +281,7 @@ msgid "UnFlag"
 msgstr "Odznačit"
 
 msgid "Login"
-msgstr "Přihlašovací jméno"
+msgstr "Přihlášení"
 
 #, php-format
 msgid "Logged-in as: %s"


### PR DESCRIPTION
Login has two meenings, but this one was incorrect, it meant "your username" in czech instead of "you can log in here".